### PR TITLE
21 unhandled timeouterror in sendtodiscord when webhook request exceeds timeout

### DIFF
--- a/on_fire_actions/send_to_discord.py
+++ b/on_fire_actions/send_to_discord.py
@@ -43,19 +43,14 @@ class SendToDiscord:
             logger.info(f"Sending message to {len(self.webhooks)} webhook(s)...")
             tasks = [self.send_to_webhook(session, url) for url in self.webhooks]
 
-            # --- The Fix: Use return_exceptions=True ---
             results = await asyncio.gather(*tasks, return_exceptions=True)
 
-            # --- Post-processing to log results ---
             success_count = 0
             for url, result in zip(self.webhooks, results, strict=False):
                 if isinstance(result, Exception):
                     # This catches TimeoutError, ClientError, etc.
-                    # We log the specific URL that failed, which is crucial for debugging.
                     logger.error(f"Failed to send to webhook {url}: {result.__class__.__name__}")
                 else:
-                    # Optional: Log success for verbosity
-                    logger.debug(f"Successfully sent to webhook {url} with status {result.status}")
                     success_count += 1
 
             logger.info(f"Message sending complete. Successful: {success_count}/{len(self.webhooks)}.")

--- a/on_fire_actions/send_to_discord.py
+++ b/on_fire_actions/send_to_discord.py
@@ -2,6 +2,7 @@ import asyncio
 from dataclasses import dataclass
 from dataclasses import field
 import logging as log
+from urllib.parse import urlparse
 
 from aiohttp import ClientSession
 from vidgear.gears.helper import logger_handler
@@ -49,7 +50,8 @@ class SendToDiscord:
             for url, result in zip(self.webhooks, results, strict=False):
                 if isinstance(result, Exception):
                     # This catches TimeoutError, ClientError, etc.
-                    logger.error(f"Failed to send to webhook {url}: [{result.__class__.__name__}] {result}")
+                    sanitized_host = urlparse(url).hostname or "invalid-host"
+                    logger.error(f"Failed to send to webhook {sanitized_host}: [{result.__class__.__name__}] {result}")
                 else:
                     success_count += 1
 

--- a/on_fire_actions/send_to_discord.py
+++ b/on_fire_actions/send_to_discord.py
@@ -49,7 +49,7 @@ class SendToDiscord:
             for url, result in zip(self.webhooks, results, strict=False):
                 if isinstance(result, Exception):
                     # This catches TimeoutError, ClientError, etc.
-                    logger.error(f"Failed to send to webhook {url}: {result.__class__.__name__}")
+                    logger.error(f"Failed to send to webhook {url}: [{result.__class__.__name__}] {result}")
                 else:
                     success_count += 1
 

--- a/on_fire_actions/send_to_discord.py
+++ b/on_fire_actions/send_to_discord.py
@@ -47,7 +47,7 @@ class SendToDiscord:
             results = await asyncio.gather(*tasks, return_exceptions=True)
 
             success_count = 0
-            for url, result in zip(self.webhooks, results, strict=False):
+            for url, result in zip(self.webhooks, results, strict=True):
                 if isinstance(result, Exception):
                     # This catches TimeoutError, ClientError, etc.
                     sanitized_host = urlparse(url).hostname or "invalid-host"


### PR DESCRIPTION
This pull request addresses a critical reliability issue in the `SendToDiscord` class where a single failed webhook request (due to a timeout or other network error) would cause the entire notification process to crash with an unhandled exception. This could result in notifications not being delivered to any of the configured webhooks.

This fix makes the system significantly more robust by ensuring that each webhook request is handled independently. A failure with one webhook will now be logged as an error, but it will not interrupt the sending process for the remaining, valid webhooks.