### PR TITLE
Fix video saving in base image and add volume mount docs (#17)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,5 +2,12 @@ __pycache__
 .idea
 .git
 .gitignore
+*.pyc
+*.pyo
+*.pyd
 env
 venv
+
+# Ignore docker-related files
+.dockerignore
+recordings

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Docker allows you to run the application in a consistent and isolated environmen
                 ```bash
                 docker run --name burning_goat_detection_container -v /path/to/your/local/recordings:/app/recordings -d burning_goat_detection
                 ```
-            -   In this example, `/path/to/your/local/recordings` is a directory on your computer where you want to save the videos. The `/app/recordings` part should match the `VIDEO_OUTPUT_DIRECTORY` in your `.env` file if you have changed it from the default.
+            -   In this example, `/path/to/your/local/recordings` is a directory on your computer where you want to save the videos. The `/app/recordings` part is the default path inside the container. If you need to change this, please see the **Using a Custom Recordings Directory** section below.
 
     -  **With GPU support (CUDA):**
         ```bash
@@ -151,7 +151,18 @@ Docker allows you to run the application in a consistent and isolated environmen
                 ```bash
                 docker run --gpus all --name burning_goat_detection_container -v /path/to/your/local/recordings:/app/recordings -d burning_goat_detection
                 ```
-            -   In this example, `/path/to/your/local/recordings` is a directory on your computer where you want to save the videos. The `/app/recordings` part should match the `VIDEO_OUTPUT_DIRECTORY` in your `.env` file if you have changed it from the default.
+            -   In this example, `/path/to/your/local/recordings` is a directory on your computer where you want to save the videos. The `/app/recordings` part is the default path inside the container. If you need to change this, please see the **Using a Custom Recordings Directory** section below.
+
+    -  **Configuring with an `.env` file:**
+        The recommended way to provide configuration (like email credentials or Discord webhooks) is to use an `.env` file with the `--env-file` flag. This securely injects all your settings into the container.
+
+        - **Example:**
+          ```bash
+          docker run --name burning_goat_detection_container \
+            --env-file .env \
+            -v /path/to/your/local/recordings:/app/recordings \
+            -d burning_goat_detection
+          ```
 
     -  **Using a Custom Recordings Directory:**
         If you wish to change the directory where videos are saved inside the container, you must update both the volume mount (`-v`) and provide the `VIDEO_OUTPUT_DIRECTORY` environment variable (`-e`). **The path for the environment variable must match the container-side path of the volume mount.**
@@ -163,6 +174,7 @@ Docker allows you to run the application in a consistent and isolated environmen
               -e VIDEO_OUTPUT_DIRECTORY=/app/custom_vids \
               -d burning_goat_detection
             ```
+
 6.  **Accessing Container Logs:** To view the application's output and check for errors, you can view the container's logs:
     ```bash
     docker logs burning_goat_detection_container

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Docker allows you to run the application in a consistent and isolated environmen
         ```bash
         docker run --name burning_goat_detection_container -d burning_goat_detection
         ```
-        -   To save video chunks to your local machine, you need to mount a volume using the `-v` flag. This maps a directory on your host machine to the `VIDEO_OUTPUT_DIRECTORY` inside the container.
+        -   To save video chunks to your local machine, you need to mount a volume using the `-v` flag. By default, this maps to `/app/recordings` inside the container.
             -   **Example:**
                 ```bash
                 docker run --name burning_goat_detection_container -v /path/to/your/local/recordings:/app/recordings -d burning_goat_detection
@@ -146,13 +146,23 @@ Docker allows you to run the application in a consistent and isolated environmen
         docker run --gpus all --name burning_goat_detection_container -d burning_goat_detection
         ```
         -   `--gpus all`:  This flag is **critical** for enabling CUDA acceleration. It tells Docker to make all available GPUs accessible to the container. If you only want to use specific GPUs, you can specify their IDs instead (e.g., `--gpus device=0,1`).
-        -   To save video chunks to your local machine, you need to mount a volume using the `-v` flag. This maps a directory on your host machine to the `VIDEO_OUTPUT_DIRECTORY` inside the container.
+        -   To save video chunks, mount a volume as shown above.
             -   **Example:**
                 ```bash
                 docker run --gpus all --name burning_goat_detection_container -v /path/to/your/local/recordings:/app/recordings -d burning_goat_detection
                 ```
             -   In this example, `/path/to/your/local/recordings` is a directory on your computer where you want to save the videos. The `/app/recordings` part should match the `VIDEO_OUTPUT_DIRECTORY` in your `.env` file if you have changed it from the default.
 
+    -  **Using a Custom Recordings Directory:**
+        If you wish to change the directory where videos are saved inside the container, you must update both the volume mount (`-v`) and provide the `VIDEO_OUTPUT_DIRECTORY` environment variable (`-e`). **The path for the environment variable must match the container-side path of the volume mount.**
+
+        -   **Example with a custom directory:**
+            ```bash
+            docker run --name burning_goat_detection_container \
+              -v /path/to/your/local/custom_vids:/app/custom_vids \
+              -e VIDEO_OUTPUT_DIRECTORY=/app/custom_vids \
+              -d burning_goat_detection
+            ```
 6.  **Accessing Container Logs:** To view the application's output and check for errors, you can view the container's logs:
     ```bash
     docker logs burning_goat_detection_container

--- a/README.md
+++ b/README.md
@@ -134,12 +134,24 @@ Docker allows you to run the application in a consistent and isolated environmen
         ```bash
         docker run --name burning_goat_detection_container -d burning_goat_detection
         ```
+        -   To save video chunks to your local machine, you need to mount a volume using the `-v` flag. This maps a directory on your host machine to the `VIDEO_OUTPUT_DIRECTORY` inside the container.
+            -   **Example:**
+                ```bash
+                docker run --name burning_goat_detection_container -v /path/to/your/local/recordings:/app/recordings -d burning_goat_detection
+                ```
+            -   In this example, `/path/to/your/local/recordings` is a directory on your computer where you want to save the videos. The `/app/recordings` part should match the `VIDEO_OUTPUT_DIRECTORY` in your `.env` file if you have changed it from the default.
 
     -  **With GPU support (CUDA):**
         ```bash
         docker run --gpus all --name burning_goat_detection_container -d burning_goat_detection
         ```
         -   `--gpus all`:  This flag is **critical** for enabling CUDA acceleration. It tells Docker to make all available GPUs accessible to the container. If you only want to use specific GPUs, you can specify their IDs instead (e.g., `--gpus device=0,1`).
+        -   To save video chunks to your local machine, you need to mount a volume using the `-v` flag. This maps a directory on your host machine to the `VIDEO_OUTPUT_DIRECTORY` inside the container.
+            -   **Example:**
+                ```bash
+                docker run --gpus all --name burning_goat_detection_container -v /path/to/your/local/recordings:/app/recordings -d burning_goat_detection
+                ```
+            -   In this example, `/path/to/your/local/recordings` is a directory on your computer where you want to save the videos. The `/app/recordings` part should match the `VIDEO_OUTPUT_DIRECTORY` in your `.env` file if you have changed it from the default.
 
 6.  **Accessing Container Logs:** To view the application's output and check for errors, you can view the container's logs:
     ```bash

--- a/dockerfile
+++ b/dockerfile
@@ -10,7 +10,7 @@ WORKDIR /app
 RUN apt-get update && \
     apt-get install --no-install-recommends -y \
     libgl1-mesa-glx libglib2.0-0 gosu && \
-    apt-get clean autoclean && \
+    apt-get clean && \
     apt-get autoremove --yes && \
     pip install --upgrade pip && \
     rm -rf /var/lib/apt/lists/*

--- a/dockerfile
+++ b/dockerfile
@@ -1,9 +1,9 @@
 FROM python:3.13-slim-bullseye
 
-ENV PYTHONDONTWRITEBYTECODE 1
-ENV PYTHONUNBUFFERED 1
-ENV PIP_NO_CACHE_DIR 1
-ENV PIP_DISABLE_PIP_VERSION_CHECK 1
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+ENV PIP_NO_CACHE_DIR=1
+ENV PIP_DISABLE_PIP_VERSION_CHECK=1
 
 WORKDIR /app
 
@@ -30,6 +30,6 @@ RUN chmod +x /usr/local/bin/entrypoint.sh
 # Set the entrypoint to our script
 ENTRYPOINT ["entrypoint.sh"]
 
-ENV PYTHONPATH "${PYTHONPATH}:/app"
+ENV PYTHONPATH="${PYTHONPATH:-}:/app"
 
 CMD ["python3", "burning_goat_detection.py"]

--- a/dockerfile
+++ b/dockerfile
@@ -9,7 +9,7 @@ WORKDIR /app
 
 RUN apt-get update && \
     apt-get install --no-install-recommends -y \
-    libgl1-mesa-glx libglib2.0-0 && \
+    libgl1-mesa-glx libglib2.0-0 gosu && \
     apt-get clean autoclean && \
     apt-get autoremove --yes && \
     pip install --upgrade pip
@@ -17,7 +17,17 @@ RUN apt-get update && \
 COPY requirements.txt .
 RUN pip install -r requirements.txt
 
+# Create the recordings directory. The RUN chown from your original fix is no longer needed here.
+RUN mkdir -p /app/recordings
+
 COPY . .
+
+# Copy the entrypoint script and make it executable
+COPY entrypoint.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+# Set the entrypoint to our script
+ENTRYPOINT ["entrypoint.sh"]
 
 ENV PYTHONPATH "${PYTHONPATH}:/app"
 

--- a/dockerfile
+++ b/dockerfile
@@ -10,8 +10,8 @@ WORKDIR /app
 RUN apt-get update && \
     apt-get install --no-install-recommends -y \
     libgl1-mesa-glx libglib2.0-0 gosu && \
-    apt-get clean && \
     apt-get autoremove --yes && \
+    apt-get clean && \
     pip install --upgrade pip && \
     rm -rf /var/lib/apt/lists/*
 

--- a/dockerfile
+++ b/dockerfile
@@ -12,7 +12,8 @@ RUN apt-get update && \
     libgl1-mesa-glx libglib2.0-0 gosu && \
     apt-get clean autoclean && \
     apt-get autoremove --yes && \
-    pip install --upgrade pip
+    pip install --upgrade pip && \
+    rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt .
 RUN pip install -r requirements.txt

--- a/dockerfile
+++ b/dockerfile
@@ -5,6 +5,8 @@ ENV PYTHONUNBUFFERED 1
 ENV PIP_NO_CACHE_DIR 1
 ENV PIP_DISABLE_PIP_VERSION_CHECK 1
 
+WORKDIR /app
+
 RUN apt-get update && \
     apt-get install --no-install-recommends -y \
     libgl1-mesa-glx libglib2.0-0 && \
@@ -12,13 +14,11 @@ RUN apt-get update && \
     apt-get autoremove --yes && \
     pip install --upgrade pip
 
-WORKDIR /code
-
 COPY requirements.txt .
 RUN pip install -r requirements.txt
 
 COPY . .
 
-USER nobody:nogroup
+ENV PYTHONPATH "${PYTHONPATH}:/app"
 
-CMD ["python", "./burning_goat_detection.py"]
+CMD ["python3", "burning_goat_detection.py"]

--- a/dockerfile_cuda
+++ b/dockerfile_cuda
@@ -99,10 +99,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python3-pip \
     python3-numpy \
     libgl1 \
+    gosu \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy OpenCV from the builder stage
 COPY --from=builder /usr/local /usr/local
+
+# Create the recordings directory. The RUN chown from your original fix is no longer needed here.
+RUN mkdir -p /app/recordings
 
 # Copy the application code
 COPY . .
@@ -113,6 +117,13 @@ RUN pip3 install -r requirements_cuda.txt
 # Remove the opencv-python package installed by pip (if any) to avoid conflicts
 # Ignore error if package does not exist.
 RUN pip3 uninstall -y opencv-python opencv-python-headless || true
+
+# Copy the entrypoint script and make it executable
+COPY entrypoint.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+# Set the entrypoint to our script
+ENTRYPOINT ["entrypoint.sh"]
 
 # Set environment variables (Optional, but good practice)
 ENV PYTHONPATH "${PYTHONPATH}:/app"

--- a/dockerfile_cuda
+++ b/dockerfile_cuda
@@ -100,6 +100,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python3-numpy \
     libgl1 \
     gosu \
+    apt-get clean && \
+    apt-get autoremove --yes && \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy OpenCV from the builder stage

--- a/dockerfile_cuda
+++ b/dockerfile_cuda
@@ -99,10 +99,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python3-pip \
     python3-numpy \
     libgl1 \
-    gosu \
-    apt-get clean && \
+    gosu && \
     apt-get autoremove --yes && \
-    && rm -rf /var/lib/apt/lists/*
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 # Copy OpenCV from the builder stage
 COPY --from=builder /usr/local /usr/local

--- a/dockerfile_cuda
+++ b/dockerfile_cuda
@@ -100,6 +100,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python3-numpy \
     libgl1 \
     gosu && \
+    pip3 install --upgrade pip && \
     apt-get autoremove --yes && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
@@ -128,7 +129,7 @@ RUN chmod +x /usr/local/bin/entrypoint.sh
 ENTRYPOINT ["entrypoint.sh"]
 
 # Set environment variables (Optional, but good practice)
-ENV PYTHONPATH "${PYTHONPATH}:/app"
+ENV PYTHONPATH="${PYTHONPATH:-}:/app"
 
 # Command to run the application
 CMD ["python3", "burning_goat_detection.py"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,6 +2,12 @@
 
 # Ensure the recordings directory exists and has the correct permissions.
 VIDEO_DIR="${VIDEO_OUTPUT_DIRECTORY:-/app/recordings}"
+
+if ! echo "$VIDEO_DIR" | grep -q '^/app/' || echo "$VIDEO_DIR" | grep -q '\.\.'; then
+    echo "Error: VIDEO_OUTPUT_DIRECTORY must be an absolute path under /app and cannot contain '..'." >&2
+    exit 1
+fi
+
 mkdir -p "$VIDEO_DIR"
 chown nobody:nogroup "$VIDEO_DIR"
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,7 @@
 
 # Set the ownership of the recordings directory to the nobody user and group.
 # This ensures that the application, running as nobody, can write to the volume.
-chown nobody:nogroup /app/recordings
+chown nobody:nogroup "${VIDEO_OUTPUT_DIRECTORY:-/app/recordings}"
 
 # Execute the command passed to this script (the Dockerfile's CMD)
 # as the nobody user. `exec` replaces the shell process with the new process,

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,8 +3,8 @@
 # Ensure the recordings directory exists and has the correct permissions.
 VIDEO_DIR="${VIDEO_OUTPUT_DIRECTORY:-/app/recordings}"
 
-if ! echo "$VIDEO_DIR" | grep -q '^/app/' || echo "$VIDEO_DIR" | grep -q '\.\.'; then
-    echo "Error: VIDEO_OUTPUT_DIRECTORY must be an absolute path under /app and cannot contain '..'." >&2
+if ! echo "$VIDEO_DIR" | grep -q '^/app/.+' || echo "$VIDEO_DIR" | grep -q '\.\.'; then
+    echo "Error: VIDEO_OUTPUT_DIRECTORY must be a subdirectory of /app and cannot contain '..'." >&2
     exit 1
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+# Set the ownership of the recordings directory to the nobody user and group.
+# This ensures that the application, running as nobody, can write to the volume.
+chown nobody:nogroup /app/recordings
+
+# Execute the command passed to this script (the Dockerfile's CMD)
+# as the nobody user. `exec` replaces the shell process with the new process,
+# ensuring that signals are passed correctly.
+#
+# We use `gosu` here, which is a lightweight `sudo` alternative perfect for containers.
+exec gosu nobody:nogroup "$@"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,10 +3,30 @@
 # Ensure the recordings directory exists and has the correct permissions.
 VIDEO_DIR="${VIDEO_OUTPUT_DIRECTORY:-/app/recordings}"
 
-if ! echo "$VIDEO_DIR" | grep -q '^/app/.+' || echo "$VIDEO_DIR" | grep -q '\.\.'; then
-    echo "Error: VIDEO_OUTPUT_DIRECTORY must be a subdirectory of /app and cannot contain '..'." >&2
+case "$VIDEO_DIR" in
+  # 1. Check for the path traversal.
+  *..*)
+    # If this matches, give a very specific error and exit.
+    echo "Error: VIDEO_OUTPUT_DIRECTORY cannot contain '..'." >&2
     exit 1
-fi
+    ;;
+
+  # 2. If the first check passed, check if the path is a valid subdir.
+  # The '/app/?*' pattern means:
+  # - Must start with /app/
+  # - Must have at least one character after the slash (`?`)
+  # - Can have anything after that (`*`)
+  /app/?*)
+    # This is the "success" case. Do nothing and continue the script.
+    ;;
+
+  # 3. If neither of the above patterns matched, it's an invalid format.
+  *)
+    # Give a clear error explaining the required format and exit.
+    echo "Error: VIDEO_OUTPUT_DIRECTORY must be a subdirectory of /app (e.g., /app/recordings)." >&2
+    exit 1
+    ;;
+esac
 
 mkdir -p "$VIDEO_DIR"
 chown nobody:nogroup "$VIDEO_DIR"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -28,7 +28,7 @@ case "$VIDEO_DIR" in
     ;;
 esac
 
-mkdir -p "$VIDEO_DIR"
+mkdir -p "$VIDEO_DIR" || { echo "Error: Failed to create directory '$VIDEO_DIR'. It might be a file or you may not have permissions." >&2; exit 1; }
 chown nobody:nogroup "$VIDEO_DIR"
 
 # Execute the command passed to this script (the Dockerfile's CMD)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,8 +1,5 @@
 #!/bin/sh
 
-# Set the ownership of the recordings directory to the nobody user and group.
-# This ensures that the application, running as nobody, can write to the volume.
-chown nobody:nogroup "${VIDEO_OUTPUT_DIRECTORY:-/app/recordings}"
 # Ensure the recordings directory exists and has the correct permissions.
 VIDEO_DIR="${VIDEO_OUTPUT_DIRECTORY:-/app/recordings}"
 mkdir -p "$VIDEO_DIR"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,6 +3,10 @@
 # Set the ownership of the recordings directory to the nobody user and group.
 # This ensures that the application, running as nobody, can write to the volume.
 chown nobody:nogroup "${VIDEO_OUTPUT_DIRECTORY:-/app/recordings}"
+# Ensure the recordings directory exists and has the correct permissions.
+VIDEO_DIR="${VIDEO_OUTPUT_DIRECTORY:-/app/recordings}"
+mkdir -p "$VIDEO_DIR"
+chown nobody:nogroup "$VIDEO_DIR"
 
 # Execute the command passed to this script (the Dockerfile's CMD)
 # as the nobody user. `exec` replaces the shell process with the new process,


### PR DESCRIPTION
This PR fixes a bug that prevented the video saving feature from working in the base dockerfile. It also updates the documentation to show users how to persist these video files.

Changes:

1. **Dockerfile**: Refactored the base dockerfile to correctly configure all dependencies, ensuring the video saving feature works reliably.
2. **README.md**: Added a section explaining how to use the -v volume mount flag with docker run to save video chunks to a local directory.