### PR TITLE
fix(docker): make intel-opencl-icd installation conditional on architecture (#55)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -185,15 +185,10 @@ ARG SETUPTOOLS_VERSION
 ARG TARGETARCH
 
 # Install OpenCL runtime libraries
-RUN apt-get update && \
-    intel_pkg="" && \
-    if [ "$TARGETARCH" = "amd64" ]; then \
-    intel_pkg="intel-opencl-icd"; \
-    fi && \
-    apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     ocl-icd-libopencl1 \
     clinfo \
-    $intel_pkg \
+    $( [ "$TARGETARCH" = "amd64" ] && echo "intel-opencl-icd" ) \
     mesa-opencl-icd \
     libjpeg-turbo8 libpng16-16 libtiff5 libavcodec58 libavformat58 libswscale5 libgtk-3-0 && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
The `intel-opencl-icd` package is not available on ARM64 architectures (e.g., Raspberry Pi), causing the build to fail. This commit makes the installation of this package conditional, ensuring it is only installed on `amd64` systems.