### PR TITLE
feat(notifications): send video chunks to Discord on fire detection (#41)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,6 +48,11 @@ EMAIL__EMAIL_PORT=""
 # --- Discord Settings ---
 DISCORD__USE_DISCORD=false
 DISCORD__HOOKS=""
+# If true, saved video chunks are uploaded to the Discord webhook(s) as they are
+# archived around a fire event (requires VIDEO__SAVE_VIDEO_CHUNKS=true). Chunks
+# larger than Discord's ~25 MB upload limit are replaced with a text fallback
+# message pointing to the local file path.
+DISCORD__SEND_VIDEO_CHUNKS=false
 
 # --- Video Archiving ---
 VIDEO__SAVE_VIDEO_CHUNKS=false

--- a/.env.tests
+++ b/.env.tests
@@ -26,6 +26,7 @@ EMAIL__MESSAGE='Dear friend... Its time... Its time to Fight Fire With Fire!'
 DISCORD__USE_DISCORD=false
 DISCORD__HOOKS=["http://test.discord.hook"]
 DISCORD__MESSAGE='Dear friend... Its time... Its time to Fight Fire With Fire!'
+DISCORD__SEND_VIDEO_CHUNKS=false
 
 VIDEO__SAVE_VIDEO_CHUNKS=false
 VIDEO__VIDEO_OUTPUT_DIRECTORY=/tmp/test-videos

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ The Gävle Goat is a giant straw goat built annually in Gävle, Sweden. It has b
     - **Memory Mode (Default):** Keeps a pre-fire buffer in RAM for minimal disk I/O, flushing video to disk only when a fire is detected. This mode is optimized for performance and reduced wear on storage devices.
     - **Disk Mode:** Continuously saves video chunks to disk, ideal for systems with limited RAM.
 - **Continuous Fire Recording:** Optionally record video for the entire duration of a fire event, plus a configured time after it is extinguished.
+- **Video Chunks to Discord:** Optionally upload each saved video chunk (pre-fire buffer and post-fire chunks) to your Discord webhook(s) as they are archived, with a text fallback for files that exceed Discord's upload limit.
 - **Dockerized Deployment:** Easily deployable with Docker, ensuring consistent performance across different environments.
 - **CUDA Acceleration (Optional):** Supports CUDA for significantly faster processing on NVIDIA GPUs.
 
@@ -107,6 +108,7 @@ pip-compile --extra=dev --extra=cpu --output-file=requirements-dev.txt pyproject
 | **Discord Settings** | | |
 | `DISCORD__USE_DISCORD` | Set to `true` to enable Discord notifications. | `false` |
 | `DISCORD__HOOKS` | Comma-separated list of Discord webhook URLs. | `""` |
+| `DISCORD__SEND_VIDEO_CHUNKS` | Set to `true` to upload saved video chunks to Discord as they are archived around a fire event. Requires `VIDEO__SAVE_VIDEO_CHUNKS=true`. | `false` |
 | | | |
 | **Video Archiving** | | |
 | `VIDEO__SAVE_VIDEO_CHUNKS` | Set to `true` to enable saving video to disk. | `false` |
@@ -131,6 +133,7 @@ pip-compile --extra=dev --extra=cpu --output-file=requirements-dev.txt pyproject
 -   **Video Buffer Mode (`VIDEO__BUFFER_MODE`):**
     -   `memory` (default): Holds a buffer of recent, compressed video frames in RAM. No data is written to disk during normal operation. When a fire is detected, this in-memory buffer is flushed to a file. This mode significantly reduces disk I/O but increases RAM usage. The amount of RAM needed is proportional to the buffer duration and video resolution/framerate.
     -   `disk`: Continuously saves video chunks to the disk. This has low RAM usage but causes constant disk I/O, which can be inefficient and cause wear on SSDs.
+-   **Sending Video Chunks to Discord (`DISCORD__SEND_VIDEO_CHUNKS`):** When enabled (alongside `DISCORD__USE_DISCORD=true` and `VIDEO__SAVE_VIDEO_CHUNKS=true`), each video chunk archived around a fire event—starting with the pre-fire buffer and continuing with the post-fire chunks—is uploaded to the configured Discord webhook(s) as it is written. This gives you an instant, playable clip of the moments around the event. Discord webhooks reject uploads larger than ~25 MB; any chunk at or above the ~24 MB limit is not uploaded, and a fallback text message pointing to the chunk's local path is sent instead (`Goat on fire! A video chunk was saved but is too large to upload to Discord. You can find it at: <path>`). To keep individual chunks small enough to upload, lower `VIDEO__VIDEO_CHUNK_LENGTH_SECONDS` and/or `VIDEO__MEMORY_BUFFER_SECONDS`.
 
 ## HOW TO RUN
 

--- a/coverage.svg
+++ b/coverage.svg
@@ -15,7 +15,7 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">77%</text>
-        <text x="80" y="14">77%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">79%</text>
+        <text x="80" y="14">79%</text>
     </g>
 </svg>

--- a/is_goat_burning/app.py
+++ b/is_goat_burning/app.py
@@ -10,9 +10,11 @@ from is_goat_burning.config import settings
 from is_goat_burning.fire_detection import StreamFireDetector
 from is_goat_burning.fire_detection.signal_handler import SignalHandler
 from is_goat_burning.logger import get_logger
+from is_goat_burning.on_fire_actions import FireEventAction
 from is_goat_burning.on_fire_actions import OnceAction
 from is_goat_burning.on_fire_actions import SendEmail
 from is_goat_burning.on_fire_actions import SendToDiscord
+from is_goat_burning.on_fire_actions import SendVideoToDiscord
 
 logger = get_logger("Application")
 
@@ -28,8 +30,12 @@ class Application:
     Attributes:
         signal_handler (SignalHandler): The application-wide signal handler.
         action_queue (asyncio.Queue[str]): A queue for communicating events.
+        video_event_queue (asyncio.Queue[str]): A queue carrying the paths of
+            saved video chunks to event-driven actions.
         on_fire_action_handler (OnceAction | None): The handler that executes
             notification actions.
+        video_event_action (FireEventAction | None): The persistent handler that
+            forwards saved video chunk paths to its wrapped action.
         action_manager_task (asyncio.Task | None): The task managing the event
             queue and triggering actions.
     """
@@ -38,7 +44,9 @@ class Application:
         """Initializes the Application instance."""
         self.signal_handler = SignalHandler()
         self.action_queue: asyncio.Queue[str] = asyncio.Queue()
+        self.video_event_queue: asyncio.Queue[str] = asyncio.Queue()
         self.on_fire_action_handler: OnceAction | None = None
+        self.video_event_action: FireEventAction | None = None
         self.action_manager_task: asyncio.Task | None = None
         self._setup_actions()
 
@@ -72,6 +80,22 @@ class Application:
             )
         self.on_fire_action_handler = OnceAction(actions)
 
+        if settings.discord.use_discord and settings.discord.send_video_chunks:
+            self.video_event_action = FireEventAction(
+                event_queue=self.video_event_queue,
+                action=(
+                    SendVideoToDiscord,
+                    {
+                        "webhooks": settings.discord.hooks,
+                    },
+                ),
+            )
+
+    @property
+    def _video_chunks_enabled(self) -> bool:
+        """Whether saved video chunks should be forwarded to an event action."""
+        return self.video_event_action is not None
+
     async def _action_manager(self) -> None:
         """Manages the action queue, triggering handlers for received events."""
         while True:
@@ -97,6 +121,8 @@ class Application:
     async def run(self) -> None:
         """Starts and manages the main application tasks with a retry loop."""
         self.action_manager_task = asyncio.create_task(self._action_manager())
+        if self.video_event_action:
+            self.video_event_action.start()
 
         while self.signal_handler.is_running():
             detector = None
@@ -108,6 +134,7 @@ class Application:
                     video_output=settings.video_output,
                     on_fire_action=self._queue_fire_event,
                     checks_per_second=settings.checks_per_second,
+                    event_queue=self.video_event_queue if self._video_chunks_enabled else None,
                 )
                 async with asyncio.TaskGroup() as tg:
                     detector_task = tg.create_task(detector())
@@ -136,6 +163,9 @@ class Application:
     async def shutdown(self) -> None:
         """Gracefully shuts down all running application tasks."""
         logger.info("Initiating graceful shutdown.")
+        if self.video_event_action:
+            await self.video_event_action.stop()
+
         tasks = []
         if self.action_manager_task and not self.action_manager_task.done():
             self.action_manager_task.cancel()

--- a/is_goat_burning/config.py
+++ b/is_goat_burning/config.py
@@ -94,11 +94,14 @@ class DiscordSettings(BaseModel):
         use_discord: If True, Discord notifications are enabled.
         hooks: A list of Discord webhook URLs.
         message: The message content to send to the webhooks.
+        send_video_chunks: If True, saved video chunks are uploaded to the
+            configured Discord webhooks as they are archived after a fire event.
     """
 
     use_discord: bool = Field(default=False)
     hooks: list[str] = Field(default_factory=list)
     message: CleanedMessage = Field(default="Dear friend... Its time... Its time to Fight Fire With Fire!")
+    send_video_chunks: bool = Field(default=False)
 
     @model_validator(mode="after")
     def check_required_fields(self) -> DiscordSettings:

--- a/is_goat_burning/fire_detection/detector_core.py
+++ b/is_goat_burning/fire_detection/detector_core.py
@@ -8,6 +8,7 @@ selected detector implementation (CPU, CUDA, or OpenCL) to check for fire.
 
 from __future__ import annotations
 
+import asyncio
 from collections.abc import AsyncGenerator
 from collections.abc import Callable
 import time
@@ -67,6 +68,7 @@ class StreamFireDetector:
         checks_per_second: float | None = None,
         lower_hsv: np.ndarray | None = None,
         upper_hsv: np.ndarray | None = None,
+        event_queue: asyncio.Queue[str] | None = None,
     ) -> StreamFireDetector:
         """Creates and asynchronously initializes a StreamFireDetector instance.
 
@@ -81,6 +83,8 @@ class StreamFireDetector:
                 None, every frame is analyzed.
             lower_hsv: An optional override for the lower HSV fire color bound.
             upper_hsv: An optional override for the upper HSV fire color bound.
+            event_queue: An optional shared queue onto which the video saver
+                publishes the paths of saved chunks for event-driven actions.
 
         Returns:
             A fully initialized StreamFireDetector instance.
@@ -90,7 +94,7 @@ class StreamFireDetector:
         # Resolve the stream URL
         resolver = YouTubeStream(url=src)
         stream_url = await resolver.resolve_url()
-        instance.stream = await VideoStreamer.create(url=stream_url)
+        instance.stream = await VideoStreamer.create(url=stream_url, event_queue=event_queue)
 
         # This assertion helps static analysis tools understand that `instance.stream`
         # is guaranteed to be initialized before it is used below.

--- a/is_goat_burning/on_fire_actions/__init__.py
+++ b/is_goat_burning/on_fire_actions/__init__.py
@@ -1,11 +1,14 @@
 """Exports the action classes for use by the main application.
 
-This module makes the primary action-related classes (`OnceAction`, `SendEmail`,
-`SendToDiscord`) available for easy importing.
+This module makes the primary action-related classes (`OnceAction`,
+`FireEventAction`, `SendEmail`, `SendToDiscord`, `SendVideoToDiscord`)
+available for easy importing.
 """
 
+from .action_containers import FireEventAction
 from .action_containers import OnceAction
 from .send_email import SendEmail
 from .send_to_discord import SendToDiscord
+from .send_video_to_discord import SendVideoToDiscord
 
-__all__ = ["SendEmail", "OnceAction", "SendToDiscord"]
+__all__ = ["SendEmail", "OnceAction", "FireEventAction", "SendToDiscord", "SendVideoToDiscord"]

--- a/is_goat_burning/on_fire_actions/action_containers.py
+++ b/is_goat_burning/on_fire_actions/action_containers.py
@@ -7,6 +7,10 @@ from dataclasses import dataclass
 from functools import partial
 from typing import Any
 
+from is_goat_burning.logger import get_logger
+
+logger = get_logger("FireEventAction")
+
 
 @dataclass(init=False, repr=False, eq=False, order=False, kw_only=True, slots=True)
 class OnceAction:
@@ -55,3 +59,76 @@ class OnceAction:
             return
         await asyncio.gather(*[action() for action in self.actions])
         self.was_performed = True
+
+
+@dataclass(init=False, repr=False, eq=False, order=False, kw_only=True, slots=True)
+class FireEventAction:
+    """A container that drives a persistent, event-driven action from a queue.
+
+    Unlike `OnceAction`, which fires its wrapped actions a single time, this
+    container runs a long-lived background task that consumes items (e.g. video
+    chunk file paths) from a shared `asyncio.Queue` and forwards each one to the
+    wrapped action. It is intended for actions that must react to a stream of
+    events over the lifetime of the application, such as uploading each new
+    video chunk to Discord.
+
+    Attributes:
+        event_queue (asyncio.Queue[str]): The queue of items to forward to the
+            wrapped action.
+        action (Callable[[str], Awaitable[Any]]): The wrapped action, invoked
+            once per item consumed from the queue.
+    """
+
+    event_queue: asyncio.Queue[str]
+    action: Callable[[str], Awaitable[Any]]
+    _task: asyncio.Task[None] | None
+
+    def __init__(
+        self,
+        event_queue: asyncio.Queue[str],
+        action: tuple[type | Callable[..., Any], dict[str, Any]],
+    ) -> None:
+        """Initializes the FireEventAction container.
+
+        Args:
+            event_queue: A shared queue from which items (file paths) are read.
+            action: A tuple of an action (a class or a function) and a dictionary
+                of keyword arguments used to initialize or bind it. The resulting
+                callable is invoked with a single positional item per event.
+        """
+        self.event_queue = event_queue
+        self._task = None
+        act, kwargs = action
+        if isinstance(act, type):
+            self.action = act(**kwargs)
+        else:
+            self.action = partial(act, **kwargs)
+
+    def start(self) -> None:
+        """Starts the background task that consumes the event queue."""
+        if self._task is None or self._task.done():
+            self._task = asyncio.create_task(self._consume())
+
+    async def _consume(self) -> None:
+        """Consumes items from the queue and forwards each to the action."""
+        while True:
+            try:
+                item = await self.event_queue.get()
+                try:
+                    await self.action(item)
+                finally:
+                    self.event_queue.task_done()
+            except asyncio.CancelledError:
+                logger.info("Fire event action task is shutting down.")
+                break
+            except Exception:
+                logger.exception("Fire event action encountered an error, but will continue running.")
+
+    async def stop(self) -> None:
+        """Cancels the background task and waits for it to finish cleanly."""
+        if self._task and not self._task.done():
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                logger.debug("Fire event action task successfully cancelled.")

--- a/is_goat_burning/on_fire_actions/action_containers.py
+++ b/is_goat_burning/on_fire_actions/action_containers.py
@@ -131,4 +131,6 @@ class FireEventAction:
             try:
                 await self._task
             except asyncio.CancelledError:
+                if not self._task.cancelled():
+                    raise
                 logger.debug("Fire event action task successfully cancelled.")

--- a/is_goat_burning/on_fire_actions/send_video_to_discord.py
+++ b/is_goat_burning/on_fire_actions/send_video_to_discord.py
@@ -115,7 +115,11 @@ class SendVideoToDiscord:
 
     async def _upload_file(self, session: ClientSession, file_path: str) -> None:
         """Reads and uploads the file concurrently to all configured webhooks."""
-        data = await asyncio.to_thread(self._read_file, file_path)
+        try:
+            data = await asyncio.to_thread(self._read_file, file_path)
+        except OSError as e:
+            logger.error(f"Could not read video chunk {file_path}: [{e.__class__.__name__}] {e}")
+            return
         filename = os.path.basename(file_path)
         logger.info(f"Uploading video chunk {filename} to {len(self.webhooks)} webhook(s)...")
         tasks = [self._post_file(session, url, data, filename) for url in self.webhooks]

--- a/is_goat_burning/on_fire_actions/send_video_to_discord.py
+++ b/is_goat_burning/on_fire_actions/send_video_to_discord.py
@@ -6,7 +6,6 @@ from dataclasses import field
 import os
 from urllib.parse import urlparse
 
-from aiohttp import ClientResponse
 from aiohttp import ClientSession
 from aiohttp import ClientTimeout
 from aiohttp import FormData
@@ -18,6 +17,10 @@ logger = get_logger("DiscordVideoSender")
 # Discord webhooks reject uploads above ~25 MB. A slightly lower ceiling is used
 # to leave headroom for the multipart envelope and avoid borderline rejections.
 DISCORD_FILE_LIMIT = 24 * 1024 * 1024
+# Discord truncates message content beyond this many characters.
+DISCORD_CHARACTER_LIMIT = 2000
+# Timeout for the small fallback JSON message sent when a file is oversized.
+FALLBACK_TIMEOUT_SECONDS = 3.0
 
 
 @dataclass(init=True, repr=False, eq=False, order=False, kw_only=True, slots=True)
@@ -58,7 +61,7 @@ class SendVideoToDiscord:
         with open(file_path, "rb") as file:
             return file.read()
 
-    async def _post_file(self, session: ClientSession, url: str, data: bytes, filename: str) -> ClientResponse:
+    async def _post_file(self, session: ClientSession, url: str, data: bytes, filename: str) -> None:
         """Uploads the video file to a single Discord webhook URL.
 
         Args:
@@ -67,9 +70,6 @@ class SendVideoToDiscord:
             data: The raw bytes of the video file.
             filename: The filename to present to Discord.
 
-        Returns:
-            The `aiohttp.ClientResponse` object from the request.
-
         Raises:
             aiohttp.ClientError: If a non-2xx status code is received.
         """
@@ -77,9 +77,8 @@ class SendVideoToDiscord:
         form.add_field("file", data, filename=filename, content_type="video/mp4")
         async with session.post(url=url, data=form, timeout=ClientTimeout(total=self.upload_timeout_seconds)) as response:
             response.raise_for_status()
-            return response
 
-    async def _post_json(self, session: ClientSession, url: str, content: str) -> ClientResponse:
+    async def _post_json(self, session: ClientSession, url: str, content: str) -> None:
         """Sends a fallback JSON message to a single Discord webhook URL.
 
         Args:
@@ -87,20 +86,16 @@ class SendVideoToDiscord:
             url: The specific webhook URL to send the message to.
             content: The message content.
 
-        Returns:
-            The `aiohttp.ClientResponse` object from the request.
-
         Raises:
             aiohttp.ClientError: If a non-2xx status code is received.
         """
         async with session.post(
             url=url,
-            json={"content": content[:2000]},  # Discord has a 2000 character limit
+            json={"content": content[:DISCORD_CHARACTER_LIMIT]},
             headers={"User-Agent": "Python/3", "Content-Type": "application/json"},
-            timeout=ClientTimeout(total=3),
+            timeout=ClientTimeout(total=FALLBACK_TIMEOUT_SECONDS),
         ) as response:
             response.raise_for_status()
-            return response
 
     def _log_results(self, results: list[object], verb: str) -> None:
         """Logs the outcome of the per-webhook requests.

--- a/is_goat_burning/on_fire_actions/send_video_to_discord.py
+++ b/is_goat_burning/on_fire_actions/send_video_to_discord.py
@@ -1,0 +1,154 @@
+"""Provides a class to upload saved video chunks to Discord webhooks."""
+
+import asyncio
+from dataclasses import dataclass
+from dataclasses import field
+import os
+from urllib.parse import urlparse
+
+from aiohttp import ClientResponse
+from aiohttp import ClientSession
+from aiohttp import ClientTimeout
+from aiohttp import FormData
+
+from is_goat_burning.logger import get_logger
+
+logger = get_logger("DiscordVideoSender")
+
+# Discord webhooks reject uploads above ~25 MB. A slightly lower ceiling is used
+# to leave headroom for the multipart envelope and avoid borderline rejections.
+DISCORD_FILE_LIMIT = 24 * 1024 * 1024
+
+
+@dataclass(init=True, repr=False, eq=False, order=False, kw_only=True, slots=True)
+class SendVideoToDiscord:
+    """An awaitable class that uploads a video file to one or more Discord webhooks.
+
+    This action is designed to be driven by a `FireEventAction` container, whose
+    background task calls it once per archived video chunk with the chunk's file
+    path. If the file is within Discord's size limit it is uploaded as a
+    multipart attachment; otherwise a fallback text message pointing to the local
+    file is sent instead.
+
+    Attributes:
+        webhooks (list[str]): A list of Discord webhook URLs to upload to.
+        upload_timeout_seconds (float): The total timeout for a single upload
+            request, in seconds.
+        oversized_message_template (str): The message sent when a file exceeds
+            the Discord upload limit. It must contain a ``{file_path}``
+            placeholder.
+    """
+
+    webhooks: list[str]
+    upload_timeout_seconds: float = 60.0
+    oversized_message_template: str = field(
+        default=("Goat on fire! A video chunk was saved but is too large to upload to Discord. You can find it at: {file_path}")
+    )
+
+    @staticmethod
+    def _read_file(file_path: str) -> bytes:
+        """Reads a file's contents in binary mode.
+
+        Args:
+            file_path: The absolute path of the file to read.
+
+        Returns:
+            The raw bytes of the file.
+        """
+        with open(file_path, "rb") as file:
+            return file.read()
+
+    async def _post_file(self, session: ClientSession, url: str, data: bytes, filename: str) -> ClientResponse:
+        """Uploads the video file to a single Discord webhook URL.
+
+        Args:
+            session: The `aiohttp.ClientSession` to use for the request.
+            url: The specific webhook URL to upload to.
+            data: The raw bytes of the video file.
+            filename: The filename to present to Discord.
+
+        Returns:
+            The `aiohttp.ClientResponse` object from the request.
+
+        Raises:
+            aiohttp.ClientError: If a non-2xx status code is received.
+        """
+        form = FormData()
+        form.add_field("file", data, filename=filename, content_type="video/mp4")
+        async with session.post(url=url, data=form, timeout=ClientTimeout(total=self.upload_timeout_seconds)) as response:
+            response.raise_for_status()
+            return response
+
+    async def _post_json(self, session: ClientSession, url: str, content: str) -> ClientResponse:
+        """Sends a fallback JSON message to a single Discord webhook URL.
+
+        Args:
+            session: The `aiohttp.ClientSession` to use for the request.
+            url: The specific webhook URL to send the message to.
+            content: The message content.
+
+        Returns:
+            The `aiohttp.ClientResponse` object from the request.
+
+        Raises:
+            aiohttp.ClientError: If a non-2xx status code is received.
+        """
+        async with session.post(
+            url=url,
+            json={"content": content[:2000]},  # Discord has a 2000 character limit
+            headers={"User-Agent": "Python/3", "Content-Type": "application/json"},
+            timeout=ClientTimeout(total=3),
+        ) as response:
+            response.raise_for_status()
+            return response
+
+    def _log_results(self, results: list[object], verb: str) -> None:
+        """Logs the outcome of the per-webhook requests.
+
+        Args:
+            results: The list of results (or exceptions) from `asyncio.gather`.
+            verb: A short description of the operation for the log message.
+        """
+        success_count = 0
+        for url, result in zip(self.webhooks, results, strict=True):
+            if isinstance(result, Exception):
+                sanitized_host = urlparse(url).hostname or "invalid-host"
+                logger.error(f"Failed to {verb} to webhook {sanitized_host}: [{result.__class__.__name__}] {result}")
+            else:
+                success_count += 1
+        logger.info(f"Video chunk {verb} complete. Successful: {success_count}/{len(self.webhooks)}.")
+
+    async def _upload_file(self, session: ClientSession, file_path: str) -> None:
+        """Reads and uploads the file concurrently to all configured webhooks."""
+        data = await asyncio.to_thread(self._read_file, file_path)
+        filename = os.path.basename(file_path)
+        logger.info(f"Uploading video chunk {filename} to {len(self.webhooks)} webhook(s)...")
+        tasks = [self._post_file(session, url, data, filename) for url in self.webhooks]
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+        self._log_results(results, "upload")
+
+    async def _send_oversized_fallback(self, session: ClientSession, file_path: str) -> None:
+        """Sends the oversized-file fallback message to all configured webhooks."""
+        content = self.oversized_message_template.format(file_path=file_path)
+        logger.info("Video chunk exceeds the Discord upload limit; sending fallback message.")
+        tasks = [self._post_json(session, url, content) for url in self.webhooks]
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+        self._log_results(results, "fallback")
+
+    async def __call__(self, file_path: str) -> None:
+        """Uploads the given video chunk to Discord, or sends a fallback message.
+
+        Args:
+            file_path: The absolute path of the saved video chunk to send.
+        """
+        try:
+            file_size = await asyncio.to_thread(os.path.getsize, file_path)
+        except OSError as e:
+            logger.error(f"Could not stat video chunk {file_path}: [{e.__class__.__name__}] {e}")
+            return
+
+        async with ClientSession() as session:
+            if file_size < DISCORD_FILE_LIMIT:
+                await self._upload_file(session, file_path)
+            else:
+                await self._send_oversized_fallback(session, file_path)

--- a/is_goat_burning/stream.py
+++ b/is_goat_burning/stream.py
@@ -106,12 +106,14 @@ class VideoStreamer:
         frame_shape (tuple[int, int]): The (width, height) of the video frames.
     """
 
-    def __init__(self, url: str, cap: cv2.VideoCapture) -> None:
+    def __init__(self, url: str, cap: cv2.VideoCapture, event_queue: asyncio.Queue[str] | None = None) -> None:
         """Initializes the VideoStreamer. Private, use `create`.
 
         Args:
             url: The direct, playable video stream URL.
             cap: An opened `cv2.VideoCapture` instance.
+            event_queue: An optional shared queue onto which the video saver
+                publishes the paths of saved chunks for event-driven actions.
         """
         self.url = url
         self.cap = cap
@@ -136,12 +138,13 @@ class VideoStreamer:
             chunk_length_seconds=settings.video.video_chunk_length_seconds,
             max_chunks=settings.video.max_video_chunks,
             chunks_to_keep_after_fire=settings.video.chunks_to_keep_after_fire,
+            event_queue=event_queue,
         )
         self.video_saver.start()
         logger.info(f"VideoStreamer initialized for backend '{self.backend}' at {self.framerate} FPS.")
 
     @classmethod
-    async def create(cls, url: str) -> VideoStreamer:
+    async def create(cls, url: str, event_queue: asyncio.Queue[str] | None = None) -> VideoStreamer:
         """Creates and asynchronously initializes a VideoStreamer instance.
 
         This factory method runs the blocking `cv2.VideoCapture` operation in
@@ -149,6 +152,8 @@ class VideoStreamer:
 
         Args:
             url: The direct, playable video stream URL.
+            event_queue: An optional shared queue onto which the video saver
+                publishes the paths of saved chunks for event-driven actions.
 
         Returns:
             A fully initialized VideoStreamer instance.
@@ -163,7 +168,7 @@ class VideoStreamer:
         if not cap.isOpened():
             raise RuntimeError(f"Could not open video stream at {url}")
 
-        return cls(url=url, cap=cap)
+        return cls(url=url, cap=cap, event_queue=event_queue)
 
     def _process_frame(self, frame: np.ndarray) -> np.ndarray | cv2.UMat | cv2.cuda.GpuMat:
         """Prepares a raw frame for the selected processing backend.

--- a/is_goat_burning/stream_recording/save_stream_to_file.py
+++ b/is_goat_burning/stream_recording/save_stream_to_file.py
@@ -76,6 +76,7 @@ class AsyncVideoChunkSaver:
     max_chunks: int
     chunks_to_keep_after_fire: int
     fps: float = 30.0
+    event_queue: asyncio.Queue[str] | None = None
     FILENAME_PREFIX: ClassVar[str] = "goat-cam_"
     FILENAME_SUFFIX: ClassVar[str] = ".mp4"
     VIDEO_CODEC: ClassVar[str] = "mp4v"
@@ -173,6 +174,23 @@ class AsyncVideoChunkSaver:
                 self.frame_queue.get_nowait()
             except asyncio.QueueEmpty:
                 break
+
+    def _publish_chunk_path(self, path: str) -> None:
+        """Publishes the absolute path of a saved chunk onto the event queue.
+
+        This is a no-op when no event queue has been configured. It must only be
+        called from the event loop thread (never from an executor), because
+        `asyncio.Queue` is not thread-safe.
+
+        Args:
+            path: The path of a video chunk that was successfully written.
+        """
+        if self.event_queue is None:
+            return
+        try:
+            self.event_queue.put_nowait(os.path.abspath(path))
+        except asyncio.QueueFull:
+            logger.error(f"Event queue is full. Failed to publish chunk {os.path.basename(path)}.")
 
     def _enforce_chunk_limit_blocking(self) -> None:
         """Deletes the oldest video chunk(s) if the `max_chunks` limit is exceeded."""
@@ -448,6 +466,8 @@ class AsyncVideoChunkSaver:
                 break
             chunk_path, event_dir = item
             await loop.run_in_executor(None, self._move_file_blocking, chunk_path, event_dir)
+            # The chunk now lives in the event directory under its original name.
+            self._publish_chunk_path(os.path.join(event_dir, os.path.basename(chunk_path)))
 
     async def _create_event_directory(self) -> str | None:
         """Creates a timestamped directory for a fire event.
@@ -526,6 +546,8 @@ class AsyncVideoChunkSaver:
         try:
             # This is a blocking I/O operation, run it in an executor
             await loop.run_in_executor(None, self._flush_buffer_to_disk_ffmpeg, buffer, path)
+            # Only publish once the chunk has been written successfully.
+            self._publish_chunk_path(path)
         except Exception as e:
             logger.error(f"Failed to flush post-fire buffer to disk: {e}", exc_info=True)
 

--- a/is_goat_burning/stream_recording/strategies.py
+++ b/is_goat_burning/stream_recording/strategies.py
@@ -260,6 +260,8 @@ class MemoryBufferStrategy(BufferStrategy):
 
         loop = asyncio.get_running_loop()
         await loop.run_in_executor(None, self.context._flush_buffer_to_disk_blocking, frames_to_flush, file_path)
+        # The pre-fire buffer has been written; publish it for event-driven actions.
+        self.context._publish_chunk_path(file_path)
 
     async def handle_fire_event(self, event_dir: str) -> None:
         """Handles the fire event for 'memory' buffering mode.

--- a/tests/on_fire_actions/test_once_action.py
+++ b/tests/on_fire_actions/test_once_action.py
@@ -1,13 +1,16 @@
-"""Unit tests for the OnceAction container.
+"""Unit tests for the action container classes.
 
 These tests verify the core idempotency logic of the `OnceAction` class,
-ensuring that wrapped actions are only executed once.
+ensuring that wrapped actions are only executed once, and the persistent,
+queue-driven behavior of the `FireEventAction` class.
 """
 
+import asyncio
 from unittest.mock import AsyncMock
 
 import pytest
 
+from is_goat_burning.on_fire_actions.action_containers import FireEventAction
 from is_goat_burning.on_fire_actions.action_containers import OnceAction
 
 
@@ -37,3 +40,84 @@ async def test_once_action_with_multiple_actions() -> None:
     # Assert that both actions were called
     mock_action_1.assert_called_once()
     mock_action_2.assert_called_once()
+
+
+async def _wait_for(condition, timeout: float = 1.0) -> None:
+    """Polls until ``condition()`` is truthy or the timeout elapses."""
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    while loop.time() < deadline:
+        if condition():
+            return
+        await asyncio.sleep(0.01)
+    raise AssertionError("Condition was not met within the timeout.")
+
+
+@pytest.mark.asyncio
+async def test_fire_event_action_forwards_queue_items_to_action() -> None:
+    """Verifies each item put on the queue is forwarded to the wrapped action."""
+    mock_action = AsyncMock()
+    queue: asyncio.Queue[str] = asyncio.Queue()
+    container = FireEventAction(event_queue=queue, action=(mock_action, {}))
+    container.start()
+
+    await queue.put("/path/one.mp4")
+    await queue.put("/path/two.mp4")
+
+    await _wait_for(lambda: mock_action.call_count == 2)
+    await container.stop()
+
+    mock_action.assert_any_await("/path/one.mp4")
+    mock_action.assert_any_await("/path/two.mp4")
+
+
+@pytest.mark.asyncio
+async def test_fire_event_action_instantiates_class_actions() -> None:
+    """Verifies a class action is instantiated with the provided kwargs."""
+
+    class RecordingAction:
+        def __init__(self, tag: str) -> None:
+            self.tag = tag
+            self.calls: list[str] = []
+
+        async def __call__(self, item: str) -> None:
+            self.calls.append(f"{self.tag}:{item}")
+
+    queue: asyncio.Queue[str] = asyncio.Queue()
+    container = FireEventAction(event_queue=queue, action=(RecordingAction, {"tag": "goat"}))
+    container.start()
+
+    await queue.put("/chunk.mp4")
+    await _wait_for(lambda: container.action.calls == ["goat:/chunk.mp4"])
+    await container.stop()
+
+
+@pytest.mark.asyncio
+async def test_fire_event_action_survives_action_errors() -> None:
+    """Verifies a failing action does not stop the consumer task."""
+    mock_action = AsyncMock(side_effect=[RuntimeError("boom"), None])
+    queue: asyncio.Queue[str] = asyncio.Queue()
+    container = FireEventAction(event_queue=queue, action=(mock_action, {}))
+    container.start()
+
+    await queue.put("/first.mp4")
+    await queue.put("/second.mp4")
+
+    await _wait_for(lambda: mock_action.call_count == 2)
+    await container.stop()
+
+    assert mock_action.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_fire_event_action_stop_cancels_task() -> None:
+    """Verifies that stop() cleanly cancels the background task."""
+    mock_action = AsyncMock()
+    queue: asyncio.Queue[str] = asyncio.Queue()
+    container = FireEventAction(event_queue=queue, action=(mock_action, {}))
+    container.start()
+
+    assert container._task is not None
+    await container.stop()
+
+    assert container._task.done()

--- a/tests/on_fire_actions/test_send_video_to_discord.py
+++ b/tests/on_fire_actions/test_send_video_to_discord.py
@@ -88,6 +88,21 @@ async def test_missing_file_sends_nothing() -> None:
 
 
 @pytest.mark.asyncio
+async def test_read_failure_after_stat_sends_nothing() -> None:
+    """Verifies a file vanishing between the stat and the read sends no request."""
+    with (
+        patch("os.path.getsize", return_value=1024),
+        patch.object(SendVideoToDiscord, "_read_file", side_effect=OSError("gone")),
+        patch("aiohttp.ClientSession.post", new_callable=MagicMock) as mock_post,
+    ):
+        sender = SendVideoToDiscord(webhooks=[WEBHOOK])
+
+        await sender("/videos/event/goat-cam_chunk.mp4")
+
+    mock_post.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_upload_continues_when_one_webhook_fails() -> None:
     """Verifies one failing webhook does not prevent uploads to the others."""
     second = "https://discord.com/api/webhooks/456/def"

--- a/tests/on_fire_actions/test_send_video_to_discord.py
+++ b/tests/on_fire_actions/test_send_video_to_discord.py
@@ -1,0 +1,107 @@
+"""Unit tests for the SendVideoToDiscord action class."""
+
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+from aiohttp import FormData
+import pytest
+
+from is_goat_burning.on_fire_actions.send_video_to_discord import DISCORD_FILE_LIMIT
+from is_goat_burning.on_fire_actions.send_video_to_discord import SendVideoToDiscord
+
+WEBHOOK = "https://discord.com/api/webhooks/123/abc"
+
+
+@pytest.mark.asyncio
+async def test_uploads_small_file_as_multipart() -> None:
+    """Verifies a file under the limit is uploaded via multipart form data."""
+    with (
+        patch("os.path.getsize", return_value=1024),
+        patch.object(SendVideoToDiscord, "_read_file", return_value=b"video-bytes"),
+        patch("aiohttp.ClientSession.post", new_callable=MagicMock) as mock_post,
+    ):
+        mock_post.return_value.__aenter__.return_value.raise_for_status = MagicMock()
+        sender = SendVideoToDiscord(webhooks=[WEBHOOK])
+
+        await sender("/videos/event/goat-cam_chunk.mp4")
+
+    mock_post.assert_called_once()
+    kwargs = mock_post.call_args.kwargs
+    assert kwargs["url"] == WEBHOOK
+    assert isinstance(kwargs["data"], FormData)
+    assert "json" not in kwargs
+
+
+@pytest.mark.asyncio
+async def test_uploads_to_all_webhooks() -> None:
+    """Verifies the file is uploaded to every configured webhook."""
+    second = "https://discord.com/api/webhooks/456/def"
+    with (
+        patch("os.path.getsize", return_value=1024),
+        patch.object(SendVideoToDiscord, "_read_file", return_value=b"video-bytes"),
+        patch("aiohttp.ClientSession.post", new_callable=MagicMock) as mock_post,
+    ):
+        mock_post.return_value.__aenter__.return_value.raise_for_status = MagicMock()
+        sender = SendVideoToDiscord(webhooks=[WEBHOOK, second])
+
+        await sender("/videos/event/goat-cam_chunk.mp4")
+
+    assert mock_post.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_oversized_file_sends_fallback_message() -> None:
+    """Verifies an oversized file triggers the JSON fallback message."""
+    file_path = "/videos/event/goat-cam_big.mp4"
+    with (
+        patch("os.path.getsize", return_value=DISCORD_FILE_LIMIT + 1),
+        patch.object(SendVideoToDiscord, "_read_file") as mock_read,
+        patch("aiohttp.ClientSession.post", new_callable=MagicMock) as mock_post,
+    ):
+        mock_post.return_value.__aenter__.return_value.raise_for_status = MagicMock()
+        sender = SendVideoToDiscord(webhooks=[WEBHOOK])
+
+        await sender(file_path)
+
+    mock_read.assert_not_called()
+    mock_post.assert_called_once()
+    kwargs = mock_post.call_args.kwargs
+    assert "data" not in kwargs
+    content = kwargs["json"]["content"]
+    assert content == (
+        f"Goat on fire! A video chunk was saved but is too large to upload to Discord. You can find it at: {file_path}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_missing_file_sends_nothing() -> None:
+    """Verifies that a stat failure results in no request being sent."""
+    with (
+        patch("os.path.getsize", side_effect=OSError("missing")),
+        patch("aiohttp.ClientSession.post", new_callable=MagicMock) as mock_post,
+    ):
+        sender = SendVideoToDiscord(webhooks=[WEBHOOK])
+
+        await sender("/videos/event/gone.mp4")
+
+    mock_post.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_upload_continues_when_one_webhook_fails() -> None:
+    """Verifies one failing webhook does not prevent uploads to the others."""
+    second = "https://discord.com/api/webhooks/456/def"
+    successful_post = MagicMock()
+    successful_post.__aenter__.return_value.raise_for_status = MagicMock()
+
+    with (
+        patch("os.path.getsize", return_value=1024),
+        patch.object(SendVideoToDiscord, "_read_file", return_value=b"video-bytes"),
+        patch("aiohttp.ClientSession.post", new_callable=MagicMock) as mock_post,
+    ):
+        mock_post.side_effect = [Exception("Test Exception"), successful_post]
+        sender = SendVideoToDiscord(webhooks=[WEBHOOK, second])
+
+        await sender("/videos/event/goat-cam_chunk.mp4")
+
+    assert mock_post.call_count == 2

--- a/tests/stream_recording/test_async_video_chunk_saver.py
+++ b/tests/stream_recording/test_async_video_chunk_saver.py
@@ -1,5 +1,7 @@
 """Unit tests for the AsyncVideoChunkSaver and its buffer strategies."""
 
+import asyncio
+import os
 from unittest.mock import MagicMock
 from unittest.mock import call
 
@@ -254,3 +256,85 @@ async def test_saver_with_memory_strategy_full_flow(mocker: MockerFixture) -> No
     # Assert post-fire flush(es)
     total_post_fire_frames = sum(len(call.args[0]) for call in mock_ffmpeg_flush.call_args_list[1:])
     assert total_post_fire_frames == frames_to_record
+
+
+# ==============================================================================
+# == Event Queue Publishing Tests
+# ==============================================================================
+
+
+def _build_disk_saver(mocker: MockerFixture, event_queue: asyncio.Queue | None) -> AsyncVideoChunkSaver:
+    """Builds a disk-mode saver with mocked filesystem for publishing tests."""
+    mock_settings = mocker.patch("is_goat_burning.stream_recording.save_stream_to_file.settings")
+    mock_settings.video.buffer_mode = "disk"
+    mocker.patch("os.makedirs")
+    return AsyncVideoChunkSaver(
+        enabled=True,
+        output_dir="test_output",
+        chunk_length_seconds=1,
+        max_chunks=1,
+        chunks_to_keep_after_fire=1,
+        event_queue=event_queue,
+    )
+
+
+def test_publish_chunk_path_puts_absolute_path(mocker: MockerFixture) -> None:
+    """Verifies the publish helper enqueues the absolute path of a chunk."""
+    queue: asyncio.Queue[str] = asyncio.Queue()
+    saver = _build_disk_saver(mocker, queue)
+
+    saver._publish_chunk_path("relative/dir/goat-cam_chunk.mp4")
+
+    assert queue.get_nowait() == os.path.abspath("relative/dir/goat-cam_chunk.mp4")
+
+
+def test_publish_chunk_path_is_noop_without_queue(mocker: MockerFixture) -> None:
+    """Verifies the publish helper is a no-op when no queue is configured."""
+    saver = _build_disk_saver(mocker, None)
+    # Should not raise.
+    saver._publish_chunk_path("some/path.mp4")
+
+
+@pytest.mark.asyncio
+async def test_flush_chunk_buffer_publishes_on_success(mocker: MockerFixture) -> None:
+    """Verifies a successful post-fire flush publishes the chunk path."""
+    queue: asyncio.Queue[str] = asyncio.Queue()
+    saver = _build_disk_saver(mocker, queue)
+    mocker.patch.object(AsyncVideoChunkSaver, "_flush_buffer_to_disk_ffmpeg")
+
+    from collections import deque
+
+    await saver._flush_chunk_buffer_to_disk_async(deque([b"frame"]), "event_dir")
+
+    published = queue.get_nowait()
+    assert published.startswith(os.path.abspath("event_dir"))
+    assert published.endswith(".mp4")
+
+
+@pytest.mark.asyncio
+async def test_flush_chunk_buffer_does_not_publish_on_failure(mocker: MockerFixture) -> None:
+    """Verifies a failed post-fire flush does not publish anything."""
+    queue: asyncio.Queue[str] = asyncio.Queue()
+    saver = _build_disk_saver(mocker, queue)
+    mocker.patch.object(AsyncVideoChunkSaver, "_flush_buffer_to_disk_ffmpeg", side_effect=OSError("boom"))
+
+    from collections import deque
+
+    await saver._flush_chunk_buffer_to_disk_async(deque([b"frame"]), "event_dir")
+
+    assert queue.empty()
+
+
+@pytest.mark.asyncio
+async def test_archive_task_publishes_moved_chunk_path(mocker: MockerFixture) -> None:
+    """Verifies archived (moved) chunks are published with their new path."""
+    queue: asyncio.Queue[str] = asyncio.Queue()
+    saver = _build_disk_saver(mocker, queue)
+    mocker.patch.object(AsyncVideoChunkSaver, "_move_file_blocking")
+
+    await saver.archive_queue.put(("/videos/goat-cam_chunk.mp4", "/videos/event_dir"))
+    await saver.archive_queue.put(None)
+
+    await saver.archive_task()
+
+    assert queue.get_nowait() == os.path.abspath("/videos/event_dir/goat-cam_chunk.mp4")

--- a/tests/stream_recording/test_saver_and_strategies.py
+++ b/tests/stream_recording/test_saver_and_strategies.py
@@ -159,6 +159,8 @@ async def test_memory_strategy_flushes_buffer_to_disk_on_fire_event(
     assert len(flushed_frames_arg) == 2
     assert list(flushed_frames_arg) == [b"frame1", b"frame2"]
     assert len(memory_strategy.memory_buffer) == 0
+    # The freshly written pre-fire chunk should be published for event-driven actions.
+    memory_strategy.context._publish_chunk_path.assert_called_once_with(memory_strategy.context.current_video_path)
 
 
 @pytest.mark.asyncio

--- a/tests/test_app_unit.py
+++ b/tests/test_app_unit.py
@@ -11,14 +11,17 @@ from unittest.mock import patch
 from is_goat_burning.app import Application
 from is_goat_burning.on_fire_actions import SendEmail
 from is_goat_burning.on_fire_actions import SendToDiscord
+from is_goat_burning.on_fire_actions import SendVideoToDiscord
 
 
-def create_mock_settings(use_emails: bool = False, use_discord: bool = False) -> MagicMock:
+def create_mock_settings(use_emails: bool = False, use_discord: bool = False, send_video_chunks: bool = False) -> MagicMock:
     """Creates a MagicMock to simulate the Settings object for testing.
 
     Args:
         use_emails: If True, the mock will be configured to enable emails.
         use_discord: If True, the mock will be configured to enable Discord.
+        send_video_chunks: If True, the mock will be configured to enable
+            sending saved video chunks to Discord.
 
     Returns:
         A MagicMock instance configured to simulate the global settings object.
@@ -35,6 +38,7 @@ def create_mock_settings(use_emails: bool = False, use_discord: bool = False) ->
     mock_settings.discord.use_discord = use_discord
     mock_settings.discord.message = "discord_message"
     mock_settings.discord.hooks = ["hook1"]
+    mock_settings.discord.send_video_chunks = send_video_chunks
     return mock_settings
 
 
@@ -91,3 +95,51 @@ def test_setup_actions_instantiates_no_actions_when_disabled(mock_once_action: M
         Application()
 
     mock_once_action.assert_called_once_with([])
+
+
+@patch("is_goat_burning.app.OnceAction")
+def test_setup_actions_wires_video_event_action_when_enabled(mock_once_action: MagicMock) -> None:  # noqa: ARG001
+    """Verifies a FireEventAction is wired when Discord video chunks are enabled."""
+    mock_settings = create_mock_settings(use_discord=True, send_video_chunks=True)
+    with (
+        patch("is_goat_burning.app.FireEventAction") as mock_fire_event_action,
+        patch("is_goat_burning.app.settings", mock_settings),
+    ):
+        app = Application()
+
+    mock_fire_event_action.assert_called_once()
+    kwargs = mock_fire_event_action.call_args.kwargs
+    assert kwargs["event_queue"] is app.video_event_queue
+    action_class, action_kwargs = kwargs["action"]
+    assert action_class is SendVideoToDiscord
+    assert action_kwargs["webhooks"] == ["hook1"]
+    assert app._video_chunks_enabled is True
+
+
+@patch("is_goat_burning.app.OnceAction")
+def test_setup_actions_skips_video_event_action_when_discord_disabled(mock_once_action: MagicMock) -> None:  # noqa: ARG001
+    """Verifies no FireEventAction is wired when Discord itself is disabled."""
+    mock_settings = create_mock_settings(use_discord=False, send_video_chunks=True)
+    with (
+        patch("is_goat_burning.app.FireEventAction") as mock_fire_event_action,
+        patch("is_goat_burning.app.settings", mock_settings),
+    ):
+        app = Application()
+
+    mock_fire_event_action.assert_not_called()
+    assert app.video_event_action is None
+    assert app._video_chunks_enabled is False
+
+
+@patch("is_goat_burning.app.OnceAction")
+def test_setup_actions_skips_video_event_action_when_chunks_disabled(mock_once_action: MagicMock) -> None:  # noqa: ARG001
+    """Verifies no FireEventAction is wired when video chunk sending is disabled."""
+    mock_settings = create_mock_settings(use_discord=True, send_video_chunks=False)
+    with (
+        patch("is_goat_burning.app.FireEventAction") as mock_fire_event_action,
+        patch("is_goat_burning.app.settings", mock_settings),
+    ):
+        app = Application()
+
+    mock_fire_event_action.assert_not_called()
+    assert app.video_event_action is None


### PR DESCRIPTION
Closes #41.

Adds an event-driven pipeline that sends saved video chunks to Discord as they are archived around a fire event, so alerts include an instant, playable clip of the moment.

## Phase 1 — Event-driven architecture foundation
- `Application` now owns a shared `video_event_queue` (`asyncio.Queue[str]`) carrying saved chunk paths.
- New `FireEventAction` container (in `action_containers.py`) runs a persistent background task that consumes paths from the queue and forwards each to a wrapped action, with clean start/stop tied to the app's asyncio lifecycle.
- `AsyncVideoChunkSaver` publishes the **absolute** path of every successfully written chunk onto the queue via a new `_publish_chunk_path` hook, called from:
  - the memory-mode pre-fire buffer flush,
  - the post-fire chunk flush (only on success — no publish on failed flush),
  - the disk-mode archive task (published with its post-move path).
- The queue is plumbed `Application → StreamFireDetector.create → VideoStreamer.create → AsyncVideoChunkSaver` via optional `event_queue` params, and is only passed down when the feature is enabled (so it never grows unbounded when off).

## Phase 2 — Discord video sending
- New `SendVideoToDiscord` action, driven by `FireEventAction` (its `__call__` receives a file path).
- Files under `DISCORD_FILE_LIMIT = 24 * 1024 * 1024` are uploaded via `aiohttp.FormData` multipart to each configured webhook; larger files fall back to a JSON message pointing at the local path.
- `os.path.getsize` and the file read are offloaded via `asyncio.to_thread` to keep the event loop non-blocking.

## Configuration
- New `DISCORD__SEND_VIDEO_CHUNKS` (default `false`) on `DiscordSettings`, wired conditionally in `Application` (only when Discord is enabled **and** the flag is set). Documented in `.env.example`, `.env.tests`, and `README.md`.

## Testing
- `PYTHONPATH=. pytest`: **110 passed, 10 skipped**.
- `ruff check .` and `ruff format --check .`: clean. `pre-commit` (incl. pydocstyle) passes.
- New/updated tests cover: the `FireEventAction` consumer (forwarding, class instantiation, error resilience, cancellation), `SendVideoToDiscord` (small-file upload, multi-webhook, oversized fallback text, missing-file no-op, partial failure), the saver publish hooks (abspath, no-op without queue, publish-on-success/not-on-failure, archive-task path), and the `Application` wiring gating.

## Design decisions
- `FireEventAction` mirrors `OnceAction`'s `(type|callable, kwargs)` action spec for consistency.
- Publishing is confined to loop-thread coroutines (never executor functions), since `asyncio.Queue` is not thread-safe.
- Disk-mode coverage (publishing archived chunks) was included in addition to the required memory-mode paths; a missing/failed move never yields a Discord message because oversized/upload paths are only reached after a successful `getsize`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)