### PR TITLE
feat(config): add hybrid_edge strategy and edge settings (#74)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,16 @@ LOGGING="INFO"
 VIDEO_OUTPUT=false
 CHECKS_PER_SECOND=1.0
 
+# --- Detection Strategy ---
+# How each frame is analysed for fire. Options:
+#   classic       Local CV only (HSV colour + motion). No network/model needed.
+#   hybrid_cloud  Local CV gatekeeper, escalates to the Gemini API for verification.
+#                 (Formerly named "hybrid"; the old value is still auto-migrated.)
+#   hybrid_edge   Local CV gatekeeper, escalates to a LOCAL model (ONNX/OpenVINO).
+#                 Runs fully offline; requires EDGE__* settings below.
+#   gemini        Send every checked frame straight to the Gemini API.
+DETECTION_STRATEGY=classic
+
 # --- Performance & Streaming ---
 OPEN_CL=false
 CUDA=false
@@ -31,11 +41,21 @@ FIRE_EXTINGUISHED_DEBOUNCE_SECONDS=5.0
 # Higher values = less sensitivity to motion. Used to filter static false positives.
 MOTION_DETECTION_THRESHOLD=25
 
-# --- Gemini Settings ---
-# DETECTION_STRATEGY="gemini"
+# --- Gemini (Cloud) Settings ---
+# Used by the "gemini" and "hybrid_cloud" strategies.
 # GEMINI__API_KEY="your-api-key"
 # GEMINI__MODEL="gemini-2.5-flash"
 # GEMINI__PROMPT="Analyze this image and determine if there is a visible fire. Ignore purely digital overlays."
+
+# --- Edge (Local Model) Settings ---
+# Used by the "hybrid_edge" strategy for fully-offline verification.
+# EDGE__MODEL_PATH is required when DETECTION_STRATEGY=hybrid_edge and must point
+# to an existing model file.
+# EDGE__MODEL_PATH="./models/yolo_v10_n.onnx"
+# EDGE__CONFIDENCE_THRESHOLD=0.5
+# Hardware backend for inference. Options: auto, cpu, cuda (NVIDIA),
+# opencl (AMD/Intel iGPU), ncs2 (Intel VPU).
+# EDGE__ACCELERATOR=auto
 
 # --- Email Settings ---
 EMAIL__USE_EMAILS=false

--- a/.env.tests
+++ b/.env.tests
@@ -39,3 +39,9 @@ VIDEO__FLUSH_NUM_THREADS=1
 VIDEO__FLUSH_THROTTLE_FRAME_INTERVAL=10
 VIDEO__FLUSH_THROTTLE_SECONDS=0.01
 VIDEO__FLUSH_THROTTLE_ENABLED=false
+
+# Edge (local model) verification. The default strategy is `classic`, so the
+# `hybrid_edge` model path is left unset; individual tests override these.
+# EDGE__MODEL_PATH=
+EDGE__CONFIDENCE_THRESHOLD=0.5
+EDGE__ACCELERATOR=auto

--- a/coverage.svg
+++ b/coverage.svg
@@ -15,7 +15,7 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">79%</text>
-        <text x="80" y="14">79%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">80%</text>
+        <text x="80" y="14">80%</text>
     </g>
 </svg>

--- a/is_goat_burning/config.py
+++ b/is_goat_burning/config.py
@@ -270,7 +270,7 @@ class EdgeSettings(BaseModel):
     """
 
     model_path: str | None = Field(default=None)
-    confidence_threshold: float = Field(default=0.5)
+    confidence_threshold: float = Field(default=0.5, ge=0.0, le=1.0)
     accelerator: Accelerator = Field(default=Accelerator.AUTO)
 
 
@@ -333,6 +333,9 @@ class Settings(BaseSettings):
     @model_validator(mode="after")
     def check_edge_model_path(self) -> Settings:
         """Validates the edge model path when the ``hybrid_edge`` strategy is active.
+
+        Returns:
+            The validated Settings instance.
 
         Raises:
             ValueError: If ``hybrid_edge`` is selected but ``EDGE__MODEL_PATH`` is

--- a/is_goat_burning/config.py
+++ b/is_goat_burning/config.py
@@ -7,7 +7,9 @@ validators to ensure that the configuration is consistent and complete.
 
 from __future__ import annotations
 
+from enum import StrEnum
 import os
+from pathlib import Path
 from typing import Annotated
 from typing import ClassVar
 from typing import Literal
@@ -237,6 +239,41 @@ class GeminiSettings(BaseModel):
         return self
 
 
+class Accelerator(StrEnum):
+    """Hardware backend used for local (edge) model inference.
+
+    Attributes:
+        AUTO: Detect the best available backend at runtime.
+        CPU: Generic CPU execution (fallback for any host).
+        CUDA: NVIDIA GPU acceleration.
+        OPENCL: OpenCL acceleration (AMD / Intel integrated GPUs).
+        NCS2: Intel Neural Compute Stick 2 (Myriad VPU).
+    """
+
+    AUTO = "auto"
+    CPU = "cpu"
+    CUDA = "cuda"
+    OPENCL = "opencl"
+    NCS2 = "ncs2"
+
+
+class EdgeSettings(BaseModel):
+    """Configuration specific to the local ``hybrid_edge`` verification strategy.
+
+    Attributes:
+        model_path: Path to the local inference model (e.g. ``.onnx`` or
+            ``.xml``). Required when ``DETECTION_STRATEGY=hybrid_edge``; its
+            existence is validated by the top-level ``Settings`` model.
+        confidence_threshold: Minimum confidence above which a detection is
+            confirmed as fire.
+        accelerator: The hardware backend to run inference on.
+    """
+
+    model_path: str | None = Field(default=None)
+    confidence_threshold: float = Field(default=0.5)
+    accelerator: Accelerator = Field(default=Accelerator.AUTO)
+
+
 class Settings(BaseSettings):
     """The main application settings model.
 
@@ -250,7 +287,9 @@ class Settings(BaseSettings):
     )
 
     source: str = Field(validation_alias="SOURCE")
-    detection_strategy: Literal["classic", "gemini", "hybrid"] = Field(default="classic", validation_alias="DETECTION_STRATEGY")
+    detection_strategy: Literal["classic", "gemini", "hybrid_cloud", "hybrid_edge"] = Field(
+        default="classic", validation_alias="DETECTION_STRATEGY"
+    )
     fire_detection_threshold: float = Field(validation_alias="FIRE_DETECTION_THRESHOLD", default=0.1)
     log_level: Literal["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"] = Field(default="INFO", validation_alias="LOGGING")
     video_output: bool = Field(validation_alias="VIDEO_OUTPUT", default=False)
@@ -270,6 +309,41 @@ class Settings(BaseSettings):
     discord: DiscordSettings = Field(default_factory=DiscordSettings)
     video: VideoSettings = Field(default_factory=VideoSettings)
     gemini: GeminiSettings = Field(default_factory=GeminiSettings)
+    edge: EdgeSettings = Field(default_factory=EdgeSettings)
+
+    @field_validator("detection_strategy", mode="before")
+    @classmethod
+    def migrate_legacy_hybrid(cls, v: object) -> object:
+        """Maps the deprecated ``hybrid`` strategy to ``hybrid_cloud``.
+
+        This preserves backward compatibility for existing deployments that
+        still set ``DETECTION_STRATEGY=hybrid``.
+
+        Args:
+            v: The raw ``detection_strategy`` value (after alias resolution).
+
+        Returns:
+            ``"hybrid_cloud"`` if the value was the legacy ``"hybrid"``,
+            otherwise the value unchanged.
+        """
+        if v == "hybrid":
+            return "hybrid_cloud"
+        return v
+
+    @model_validator(mode="after")
+    def check_edge_model_path(self) -> Settings:
+        """Validates the edge model path when the ``hybrid_edge`` strategy is active.
+
+        Raises:
+            ValueError: If ``hybrid_edge`` is selected but ``EDGE__MODEL_PATH`` is
+                unset or points to a file that does not exist.
+        """
+        if self.detection_strategy == "hybrid_edge":
+            if not self.edge.model_path:
+                raise ValueError("EDGE__MODEL_PATH must be set when DETECTION_STRATEGY is 'hybrid_edge'")
+            if not Path(self.edge.model_path).is_file():
+                raise ValueError(f"EDGE__MODEL_PATH points to a non-existent file: {self.edge.model_path}")
+        return self
 
 
 # A single, validated instance to be used across the application.

--- a/is_goat_burning/fire_detection/detectors.py
+++ b/is_goat_burning/fire_detection/detectors.py
@@ -474,24 +474,37 @@ def create_fire_detector(
                      the global `settings.open_cl`.
         use_cuda: Explicitly request the CUDA detector. If None, uses
                   the global `settings.cuda`.
-        strategy: The detection strategy to use ("classic", "gemini", or "hybrid").
-                  If None, uses `settings.detection_strategy`.
+        strategy: The detection strategy to use ("classic", "gemini",
+                  "hybrid_cloud", or the legacy alias "hybrid"). If None, uses
+                  `settings.detection_strategy`.
 
     Returns:
         An instance of a class that conforms to the FireDetector protocol.
+
+    Raises:
+        NotImplementedError: If the ``hybrid_edge`` strategy is requested, as the
+            local edge inference detector is not yet available.
     """
     selected_strategy = strategy if strategy is not None else settings.detection_strategy
 
-    if selected_strategy in ("gemini", "hybrid"):
+    # "hybrid" is the deprecated alias for "hybrid_cloud" (see Settings migration).
+    cloud_hybrid_strategies = ("hybrid_cloud", "hybrid")
+
+    if selected_strategy == "hybrid_edge":
+        raise NotImplementedError(
+            "The 'hybrid_edge' strategy is not yet implemented; use 'classic', 'gemini', or 'hybrid_cloud'."
+        )
+
+    if selected_strategy == "gemini" or selected_strategy in cloud_hybrid_strategies:
         from is_goat_burning.fire_detection.gemini_detector import GeminiFireDetector
 
     if selected_strategy == "gemini":
         return GeminiFireDetector()
 
-    # For both "classic" and "hybrid", we need a local detector.
+    # For both "classic" and the cloud hybrid strategies, we need a local detector.
     local_detector = _create_local_detector(margin, lower, upper, use_open_cl, use_cuda)
 
-    if selected_strategy == "hybrid":
+    if selected_strategy in cloud_hybrid_strategies:
         gemini_detector = GeminiFireDetector()
         return HybridFireDetector(local_detector, gemini_detector)
     # "classic" strategy

--- a/tests/fire_detection/test_hybrid_detector.py
+++ b/tests/fire_detection/test_hybrid_detector.py
@@ -150,3 +150,19 @@ def test_create_fire_detector_factory_returns_hybrid_when_requested(
     assert isinstance(detector, HybridFireDetector)
     assert isinstance(detector.local_detector, CPUFireDetector)
     assert isinstance(detector.gemini_detector, GeminiFireDetector)
+
+
+@pytest.mark.parametrize("strategy", ["hybrid_cloud", "hybrid"])
+def test_create_fire_detector_factory_returns_hybrid_for_cloud_strategies(
+    strategy: str,
+    mock_genai_client: MagicMock,  # noqa: ARG001
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verifies the factory returns a HybridFireDetector for `hybrid_cloud` and legacy `hybrid`."""
+    monkeypatch.setattr(settings.gemini, "api_key", SecretStr("fake-key"))
+
+    detector = create_fire_detector(TEST_MARGIN, LOWER_HSV, UPPER_HSV, use_open_cl=False, use_cuda=False, strategy=strategy)
+
+    assert isinstance(detector, HybridFireDetector)
+    assert isinstance(detector.local_detector, CPUFireDetector)
+    assert isinstance(detector.gemini_detector, GeminiFireDetector)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -7,13 +7,16 @@ Video).
 
 import importlib
 import os
+from pathlib import Path
 
 from _pytest.monkeypatch import MonkeyPatch
 from pydantic import ValidationError
 import pytest
 
 from is_goat_burning import config
+from is_goat_burning.config import Accelerator
 from is_goat_burning.config import DiscordSettings
+from is_goat_burning.config import EdgeSettings
 from is_goat_burning.config import EmailSettings
 from is_goat_burning.config import Settings
 from is_goat_burning.config import VideoSettings
@@ -82,6 +85,73 @@ def test_ffmpeg_capture_options_env_var_is_set_correctly(monkeypatch: MonkeyPatc
     monkeypatch.delenv("STREAM_INACTIVITY_TIMEOUT")
     importlib.reload(config)
     assert os.environ["OPENCV_FFMPEG_CAPTURE_OPTIONS"] == f"timeout;{DEFAULT_INACTIVITY_TIMEOUT * MICROSECONDS_PER_SECOND}"
+
+
+def test_detection_strategy_hybrid_maps_to_hybrid_cloud(monkeypatch: MonkeyPatch) -> None:
+    """Verifies the legacy `hybrid` strategy is auto-migrated to `hybrid_cloud`."""
+    monkeypatch.setenv("DETECTION_STRATEGY", "hybrid")
+    assert Settings().detection_strategy == "hybrid_cloud"
+
+
+def test_detection_strategy_hybrid_cloud_is_accepted(monkeypatch: MonkeyPatch) -> None:
+    """Verifies the new `hybrid_cloud` strategy is a valid value."""
+    monkeypatch.setenv("DETECTION_STRATEGY", "hybrid_cloud")
+    assert Settings().detection_strategy == "hybrid_cloud"
+
+
+def test_detection_strategy_hybrid_edge_requires_model_path(monkeypatch: MonkeyPatch) -> None:
+    """Verifies `hybrid_edge` fails validation when no model path is configured."""
+    monkeypatch.setenv("DETECTION_STRATEGY", "hybrid_edge")
+    with pytest.raises(ValidationError, match="EDGE__MODEL_PATH must be set"):
+        Settings()
+
+
+def test_detection_strategy_hybrid_edge_requires_existing_model_file(monkeypatch: MonkeyPatch) -> None:
+    """Verifies `hybrid_edge` fails validation when the model file does not exist."""
+    monkeypatch.setenv("DETECTION_STRATEGY", "hybrid_edge")
+    monkeypatch.setenv("EDGE__MODEL_PATH", "/nonexistent/path/to/model.onnx")
+    with pytest.raises(ValidationError, match="EDGE__MODEL_PATH"):
+        Settings()
+
+
+def test_detection_strategy_hybrid_edge_with_valid_model_file(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
+    """Verifies `hybrid_edge` validates successfully when the model file exists."""
+    model_file = tmp_path / "model.onnx"
+    model_file.write_bytes(b"fake-model")
+    monkeypatch.setenv("DETECTION_STRATEGY", "hybrid_edge")
+    monkeypatch.setenv("EDGE__MODEL_PATH", str(model_file))
+    settings = Settings()
+    assert settings.detection_strategy == "hybrid_edge"
+    assert settings.edge.model_path == str(model_file)
+
+
+def test_hybrid_edge_validation_skipped_for_other_strategies() -> None:
+    """Verifies the edge model-path check is only enforced for `hybrid_edge`."""
+    # Default strategy is `classic` with no EDGE__MODEL_PATH; this must not raise.
+    settings = Settings()
+    assert settings.detection_strategy == "classic"
+    assert settings.edge.model_path is None
+
+
+def test_edge_settings_defaults() -> None:
+    """Verifies EdgeSettings applies the documented defaults."""
+    edge = EdgeSettings()
+    assert edge.model_path is None
+    assert edge.confidence_threshold == 0.5
+    assert edge.accelerator == Accelerator.AUTO
+
+
+@pytest.mark.parametrize("value", ["auto", "cpu", "cuda", "opencl", "ncs2"])
+def test_edge_accelerator_accepts_valid_values(value: str) -> None:
+    """Verifies every documented accelerator value is accepted."""
+    edge = EdgeSettings(accelerator=value)
+    assert edge.accelerator == value
+
+
+def test_edge_accelerator_rejects_invalid_value() -> None:
+    """Verifies an unsupported accelerator value fails validation."""
+    with pytest.raises(ValidationError):
+        EdgeSettings(accelerator="quantum")
 
 
 @pytest.mark.parametrize(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -104,7 +104,7 @@ def test_detection_strategy_hybrid_edge_requires_model_path(monkeypatch: MonkeyP
     monkeypatch.setenv("DETECTION_STRATEGY", "hybrid_edge")
     monkeypatch.delenv("EDGE__MODEL_PATH", raising=False)
     with pytest.raises(ValidationError, match="EDGE__MODEL_PATH must be set"):
-        Settings()
+        Settings(_env_file=".env.tests")
 
 
 def test_detection_strategy_hybrid_edge_requires_existing_model_file(monkeypatch: MonkeyPatch) -> None:
@@ -131,7 +131,7 @@ def test_hybrid_edge_validation_skipped_for_other_strategies(monkeypatch: Monkey
     # Default strategy is `classic` with no EDGE__MODEL_PATH; this must not raise.
     monkeypatch.setenv("DETECTION_STRATEGY", "classic")
     monkeypatch.delenv("EDGE__MODEL_PATH", raising=False)
-    settings = Settings()
+    settings = Settings(_env_file=".env.tests")
     assert settings.detection_strategy == "classic"
     assert settings.edge.model_path is None
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -102,6 +102,7 @@ def test_detection_strategy_hybrid_cloud_is_accepted(monkeypatch: MonkeyPatch) -
 def test_detection_strategy_hybrid_edge_requires_model_path(monkeypatch: MonkeyPatch) -> None:
     """Verifies `hybrid_edge` fails validation when no model path is configured."""
     monkeypatch.setenv("DETECTION_STRATEGY", "hybrid_edge")
+    monkeypatch.delenv("EDGE__MODEL_PATH", raising=False)
     with pytest.raises(ValidationError, match="EDGE__MODEL_PATH must be set"):
         Settings()
 
@@ -125,9 +126,11 @@ def test_detection_strategy_hybrid_edge_with_valid_model_file(monkeypatch: Monke
     assert settings.edge.model_path == str(model_file)
 
 
-def test_hybrid_edge_validation_skipped_for_other_strategies() -> None:
+def test_hybrid_edge_validation_skipped_for_other_strategies(monkeypatch: MonkeyPatch) -> None:
     """Verifies the edge model-path check is only enforced for `hybrid_edge`."""
     # Default strategy is `classic` with no EDGE__MODEL_PATH; this must not raise.
+    monkeypatch.setenv("DETECTION_STRATEGY", "classic")
+    monkeypatch.delenv("EDGE__MODEL_PATH", raising=False)
     settings = Settings()
     assert settings.detection_strategy == "classic"
     assert settings.edge.model_path is None
@@ -152,6 +155,13 @@ def test_edge_accelerator_rejects_invalid_value() -> None:
     """Verifies an unsupported accelerator value fails validation."""
     with pytest.raises(ValidationError):
         EdgeSettings(accelerator="quantum")
+
+
+@pytest.mark.parametrize("value", [-0.1, 1.1])
+def test_edge_confidence_threshold_rejects_out_of_range(value: float) -> None:
+    """Verifies confidence_threshold is constrained to the [0.0, 1.0] range."""
+    with pytest.raises(ValidationError):
+        EdgeSettings(confidence_threshold=value)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Implements #74 (part of #72): refactors `DETECTION_STRATEGY` to disambiguate cloud vs. edge hybrid verification, with backward compatibility.

- Renames `hybrid` → `hybrid_cloud` and adds a new `hybrid_edge` strategy.
- Adds an `Accelerator` `StrEnum` (`auto`, `cpu`, `cuda`, `opencl`, `ncs2`) and an `EdgeSettings` model (`EDGE__` prefix): `model_path`, `confidence_threshold` (default `0.5`), `accelerator` (default `auto`).
- Backward compatibility: a `field_validator(mode="before")` auto-migrates the legacy `hybrid` value to `hybrid_cloud`.
- Validation: `EDGE__MODEL_PATH` must be set and exist on disk — enforced **only** when `hybrid_edge` is active, so the default `classic` never trips it at import time.
- Detector factory recognizes `hybrid_cloud` (and legacy `hybrid`); `hybrid_edge` raises a clear `NotImplementedError` (edge detector arrives in #76–78) rather than silently downgrading to classic.
- Documents the strategies and `EDGE__*` vars in `.env.example` and `.env.tests`.

## Note on approach

The issue prescribed a `model_validator(mode="before")` for the migration; I used a **`field_validator(mode="before")`** instead. It receives the value after alias resolution, avoiding fragile assumptions about whether the raw settings dict is keyed by `detection_strategy` or `DETECTION_STRATEGY`. Same behavior, more robust.

## Testing

- New unit tests in `tests/test_config.py`: `hybrid`→`hybrid_cloud` migration (via the real env path), missing/non-existent/valid `model_path`, and accelerator enum validation.
- New factory test in `tests/fire_detection/test_hybrid_detector.py` for `hybrid_cloud`.
- Full suite: **126 passed, 10 skipped**. `ruff check` and `ruff format --check` clean.
- Verified end-to-end in a fresh process: `DETECTION_STRATEGY=hybrid` → `hybrid_cloud`; `hybrid_edge` without a model path fails at import with the intended message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)